### PR TITLE
Fix: Buton Iesire Meniu Adauga Reteta

### DIFF
--- a/caloriesense/lib/adauga/adaugareteta.dart
+++ b/caloriesense/lib/adauga/adaugareteta.dart
@@ -143,9 +143,23 @@ class _AdaugaRetetaState extends State<AdaugaReteta> {
                 },
               ),
               const Spacer(),
-              ElevatedButton(
-                onPressed: salveazaReteta,
-                child: const Text('Salvează Rețeta'),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  ElevatedButton(
+                    style:
+                        ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                    onPressed: () {
+                      // Navighează înapoi fără a salva
+                      Navigator.pop(context);
+                    },
+                    child: const Text('Iesire'),
+                  ),
+                  ElevatedButton(
+                    onPressed: salveazaReteta,
+                    child: const Text('Salvează Rețeta'),
+                  ),
+                ],
               ),
             ],
           ),


### PR DESCRIPTION
Ce face acest PR?

Rezolva problema in care nu exista un buton de anulare sau iesire din meniul de adaugare reteta.

Referință la problemă:
Rezolvă #1

Modificări:
A fost adaugat un buton de iesire langa cel de Salvare Reteta.